### PR TITLE
added support for integrating selected data with plotly

### DIFF
--- a/lib/glow/graph.js
+++ b/lib/glow/graph.js
@@ -621,6 +621,50 @@
 								Plotly.newPlot(this.__id, [ {x:[], y:[], mode:p, type:'scatter', 
 									name:s.__label, showlegend:s.__legend, visible:s.__visible,
 									marker:{color:col, size:2*s.__radius}} ], layout)
+									
+								//begin Aaron Titus
+								//integrate selected data
+								if(s.__integrate_selected){
+									var myPlot = document.getElementById(this.__id) //graph div
+									myPlot.on('plotly_selected', function(eventData){
+										var x = [] //x points of selected data
+										var y = [] //y points of selected data
+										if(eventData !== undefined){
+											eventData.points.forEach(function(pt) {
+												x.push(pt.x)
+												y.push(pt.y)
+											})
+											var sum=0 //integral
+											for(var i=1; i<x.length; i++){
+												var dx=x[i]-x[i-1]
+												sum=sum+(y[i]+y[i-1])/2*dx //trapezoidal rule
+											}
+											var layoutupdate = { //add annotation to the layout
+												annotations: [
+													{
+														text: '<b>integral of selected points = '+sum.toPrecision(6) + '</b>',
+														font: {
+															color: "black",
+															size: 14
+														},
+														showarrow: false
+													}
+												]
+											}
+											Plotly.relayout(myPlot, layoutupdate)
+											//add new trace for selected data
+											for (var t=0; t< myPlot.data.length; t++){
+												if(myPlot.data[t]['name']=='selected data'){
+													Plotly.deleteTraces(myPlot, t);
+												}
+											}
+											Plotly.addTraces(myPlot, {x:x, y:y, type:'scatter', fill:'tozeroy', 
+												mode:'none', name:'selected data', showlegend:false, hoverinfo:'none'
+											})
+										}
+									})
+								}
+								//end Aaron Titus
 							}
 						} else {
 						if (p == 'bar') Plotly.addTraces(this.__id, {x:[], y:[], type:p,
@@ -768,6 +812,7 @@
         this.__legend = false
         this.__markers = false
         this.__interval = -1 // -1 signals no interval specified; 0 signals no plotting
+        this.__integrate_selected = false //Aaron Titus
         var fast = true
         if (options.fast !== undefined){
         	fast = options.fast
@@ -911,7 +956,10 @@
             this.__ninterval = options.interval
             delete options.interval
         }
-        
+        if (options.integrate_selected !== undefined){
+        	this.__integrate_selected = options.integrate_selected
+        	delete options.integrate_selected
+        }        
         this.__visible = true
         if (options.visible !== undefined) {
             this.__visible = options.visible


### PR DESCRIPTION
If using Plotly, one can use the Box Select or Lasso Select tool and select data in a scatterplot. The area under the curve will be shaded, and the integral will be printed.

Here is a simple example program that illustrates the feature:

```
g = gdots(fast=False, integrate_selected=True)
for t in arange(0,10,0.01):
    g.plot(t, cos(t))
```

I have not tested it with `gcurve(fast=False, integrate_selected=True)`. Because this also produces a Plotly scatterplot, it's possible that the data can be selected in this case too. Plotly only shows the selection tools for a scatterplot. Thus, this feature won't work for a default `gcurve()`.