### PR TITLE
Fix rotate bug on touch devices

### DIFF
--- a/lib/glow/orbital_camera.js
+++ b/lib/glow/orbital_camera.js
@@ -291,7 +291,7 @@
 			    if (data.length == 2) { // two-finger gesture
 			  		saveEvent = null
 			  	} else {
-			  		var near = (relx[0] <= 5 && rely[0] <= 5)
+			  		var near = (Math.abs(relx[0]) <= 5 && Math.abs(rely[0]) <= 5)
 			  		if (!rotating && t > 150 && near) {
 			  			// The following triggers a mousedown event from within a touchmove
 			  			// context, with the result that the mousemove event above gets
@@ -351,7 +351,7 @@
                 if (!(rotating || zooming)) {
 				    ev.type = "mouseup"
 	                canvas.trigger("mouse", ev) // the up event
-	                	if (abs(ev.pageX - downX[0]) <= 5 && abs(ev.pageY - downY[0]) <= 5) {
+	                	if (Math.abs(ev.pageX - downX[0]) <= 5 && Math.abs(ev.pageY - downY[0]) <= 5) {
 	                		ev.type = "click"
 	                		canvas.trigger("mouse", ev) // add a click event
 	                	}


### PR DESCRIPTION
On touchscreen devices, rotating left or up would mostly not work,
unless the gesture started by moving down or right, and then
doubled back.

Also cleaning up an inappropriate reference to abs() vs. Math.abs().