### PR TITLE
Debug makeSphere, makeCurveSegment

### DIFF
--- a/lib/glow/WebGLRenderer.js
+++ b/lib/glow/WebGLRenderer.js
@@ -168,7 +168,8 @@
         	if (dynamism) this.dynamism = gl.DYNAMIC_DRAW
         	else this.dynamism = gl.STATIC_DRAW // cannot change the built-in models
         	this.elementType = gl.TRIANGLES
-    		this.mesh = mesh
+        	//this.elementType = gl.LINE_LOOP   // wireframe for debugging
+			this.mesh = mesh
         	this.model_transparent = mesh.model_transparent
             this.pos = new Float32Array(mesh.pos)
             this.normal = new Float32Array(mesh.normal)

--- a/lib/glow/mesh.js
+++ b/lib/glow/mesh.js
@@ -456,7 +456,7 @@
                 x2 = 0
                 y2 = y1*cost+z1*sint // bottom latitude in this latitude band
                 z2 = z1*cost-y1*sint
-                for (j=0; j<Nlong+1; j++) { 
+                for (j=0; j<offset; j++) { 
                     m.pos.push( x1, y1, z1 )
                     m.normal.push( x1/R, y1/R, z1/R )
                     m.color.push( 1, 1, 1 )
@@ -470,15 +470,15 @@
                     newz1 = z1*cosp-x1*sinp
                     x1 = newx1
                     z1 = newz1
-                    if (hemi && j >= Nlong) break
                 
-                    if (j < Nlong && i < Nlat) m.index.push( s+j,s+j+offset,s+j+offset+1, s+j,s+j+offset+1,s+j+1 )
-                    // else m.index.push( s+j,s+j+offset,s+0+offset, s+j,s+0+offset,s+0 )
+                    m.index.push( s+j,s+j+offset,s+j+offset+1, s+j,s+j+offset+1,s+j+1 )
                 }
+                m.index.length -= 6 // discard last set of indices
                 x1 = x2
                 y1 = y2
                 z1 = z2
             }
+            m.index.length -= 6*(offset-1) // discard entire last band of indices
             return m
         },
 

--- a/lib/glow/mesh.js
+++ b/lib/glow/mesh.js
@@ -416,18 +416,23 @@
             return m
         },
         
-
         makeSphere: function(R, N, hemi) {
+            // A UV sphere: vertices are on latitude-longitude lines, total points = (Nlat+1)*(Nlong+1).
+            // Points at the poles and the "Date Line" are degenerate (i.e., not "welded").
+            // This simplifies the code and might render textures better.
+            // The hemi flag creates an "Eastern hemisphere" (x > 0), open on the other side,
+            // and is primarily used as an endcap for the curve object.
+            // 
             // A scheme which used spherical symmetry didn't save any time and was somewhat harder to read.
             // An improvement would be to offset alternate latitudes by dphi/2 to make equilateral triangles.
             var Nlat = N, Nlong = N   // number of latitude and longitude slices
-            var offset = Nlong // index offset to next latitude
+            var offset = Nlong+1  // index offset to next latitude (seam points are degenerate)
             var dtheta = Math.PI/Nlat   // polar angle (latitude)
             var dphi = 2*Math.PI/Nlong  // azimuthal angle (longitude)
             var sint = Math.sin(dtheta), cost = Math.cos(dtheta)
             var sinp = Math.sin(dphi), cosp = Math.cos(dphi)
-            var offset = Nlong
-            if (hemi) { // make rightmost hemisphere, for curve object
+
+            if (hemi) {
             	Nlat = N/2
             	Nlong = 4
             	offset = Nlong+1 // one more because the hemisphere latitude slice doesn't wrap around
@@ -441,24 +446,25 @@
             // sin(theta+dtheta) = sin(theta)*cost + cos(theta)*sint
             // cos(theta+dtheta) = cos(theta)*cost - sin(theta)*sint
             var m = new Mesh()
-            var x1, x2, y1, y2, z1, z2, newx1, newz1, s, firstz2
-            var i, j
+            var x1, x2, y1, y2, z1, z2, newx1, newz1
+            var i, j, s
             x1 = 0
             y1 = R // topmost latitude in this latitude band
             z1 = 0
             for (i=0; i<Nlat+1; i++) {
+                s = i*offset // starting index for this latitude band
                 x2 = 0
                 y2 = y1*cost+z1*sint // bottom latitude in this latitude band
-                firstz2 = z2 = z1*cost-y1*sint
+                z2 = z1*cost-y1*sint
                 for (j=0; j<Nlong+1; j++) { 
-                    m.pos.push( x1,y1,z1 )
-                    m.normal.push( x1/R,y1/R,z1/R )
-                    m.color.push( 1,1,1 )
+                    m.pos.push( x1, y1, z1 )
+                    m.normal.push( x1/R, y1/R, z1/R )
+                    m.color.push( 1, 1, 1 )
                     m.opacity.push( 1 )
                     m.shininess.push( 1 )
                     m.emissive.push( 0 )
-                    m.texpos.push( j/Nlong,1-i/Nlat )
-                    m.bumpaxis.push( z1/R,0,-x1/R )
+                    m.texpos.push( j/Nlong, 1-i/Nlat )
+                    m.bumpaxis.push( z1/R, 0, -x1/R )
                 
                     newx1 = x1*cosp+z1*sinp
                     newz1 = z1*cosp-x1*sinp
@@ -466,30 +472,12 @@
                     z1 = newz1
                     if (hemi && j >= Nlong) break
                 
-                    s = i*offset
-                    if (j < Nlong) m.index.push( s+j,s+j+offset,s+j+offset+1, s+j,s+j+offset+1,s+j+1 )
-                    else m.index.push( s+j,s+j+offset,s+0+offset, s+j,s+0+offset,s+0 )
+                    if (j < Nlong && i < Nlat) m.index.push( s+j,s+j+offset,s+j+offset+1, s+j,s+j+offset+1,s+j+1 )
+                    // else m.index.push( s+j,s+j+offset,s+0+offset, s+j,s+0+offset,s+0 )
                 }
-                x1 = 0
+                x1 = x2
                 y1 = y2
-                z1 = firstz2
-	            if (i == Nlat) {
-	            	z1 = 0 // to make it possible to calculate bumpaxis
-	                for (j=0; j<Nlong; j+=1) {
-	                    m.pos.push( 0,-R,0 )
-	                    m.normal.push( -1,0,0 )
-                        m.color.push( 1,1,1 )
-                        m.opacity.push( 1 )
-                        m.shininess.push( 1 )
-                        m.emissive.push( 0 )
-                        m.texpos.push( j/Nlong,0 )
-	                    m.bumpaxis.push( z1/R,0,-x1/R )
-                        newx1 = x1*cosp+z1*sinp
-                        newz1 = z1*cosp-x1*sinp
-	                    x1 = newx1
-	                    z1 = newz1
-	                }
-	            }
+                z1 = z2
             }
             return m
         },
@@ -634,7 +622,7 @@
             
             var offset = m.pos.length/4 // add sphere data to cylinder data
             var sph = Mesh.makeSphere(R, N, true) // make rightmost hemisphere
-            var L = sph.pos.length
+            var L = sph.pos.length/3
             for(var i=0; i<L; i++) {
                 m.pos.push( sph.pos[3*i], sph.pos[3*i+1], sph.pos[3*i+2], 1 )
                 m.normal.push(sph.normal[3*i], sph.normal[3*i+1], sph.normal[3*i+2])


### PR DESCRIPTION
Spheres were created with Nlong too many points at the south pole, even though the poles already had degenerate points.  These extra points masked an indexing error that arose when creating hemispheres.

The index offset was off by 1, so some tris in each latitude band were degenerate.

A length bug in makeCurveSegment caused far too many points (mostly with undefined data) to be added to the curve mesh when attaching the hemisphere endcap.

These fixes reduce verts/tris by 3%/6% for spheres, 9%/21% for simple spheres, and 56%/8% for curve segments, with no change in rendered resolution.
