### PR TITLE
Make JavaScript programs work with async-await

### DIFF
--- a/lib/compiling/GScompiler.js
+++ b/lib/compiling/GScompiler.js
@@ -204,6 +204,7 @@ where compile() was called, in untrusted/run.js.
 	var classes =  []       // list of names of classes
 	var classinstances = [] // list of instances of classes; each element is [class, instance]]
 	var classmethods = []   // list of names of methods of classes; each element is [class, method]
+	var possibleclasses = {} // {possible class: [methods]} based on a function followed by embedded functions
 	var delim = '"'
 	
 	var lineno_string = 'RS_ls = ' // prepended to quoted line number; used in error return
@@ -225,20 +226,21 @@ where compile() was called, in untrusted/run.js.
 	
 	function preprocess(program, lang) { // manipulate the program source
 		// The preprocessing includes inserting RS_ls = "line number" to enable error reporting of original source line
-		if (lang == 'javascript') throw new Error("3.0dev does not yet work with JavaScript programs.")
-		if (lang != 'javascript') classinstances.push('self')
-		else classinstances.push('this')
+		if (lang == 'rapydscript') throw new Error("GlowScript RapydScript is not available after GlowScript 2.9.Choose GlowScript VPython instead.")
+		//if (lang == 'javascript') throw new Error("3.0dev does not yet work with JavaScript programs.")
+		if (lang == 'vpython') classinstances.push('self')
+		//else classinstances.push('this')
 		var c, lineno, lines, line, m, start
-		var singlequote, doublequote, triplequote
+		var singlequote, doublequote, triplequote, backquote // backquote is ` used in JavaScript
     	var parens = 0, brackets = 0, braces = 0
     	var prebraces // the braces at the start of processing a line
     	var lastleftparens = null, lastleftbracket = null, lastleftbrace = null
 	    var indent = ''
     	var getline = /(^\s*)(.*)/
     	var newprogram = '', lastindent = ''
-    	var firstquote = 0 // 0: no string; 1: string starts with '; 2: string starts with " (or """)
     	var continuedline = false
-    	var indef = false // true if processing an anonymous def in RapydScript
+		var indef = false // true if processing an anonymous def in RapydScript
+		var lastfct = ''  // The most recent unembedded JavaScript function; if encounter a function when braces == 1, might be a class
     	var classindent = -1 // class indent if processing a class, else -1
 		const pickpatt = /(\.pick)\s*(.)/
 	    var print_optionspatt = /^print_options/
@@ -249,7 +251,7 @@ where compile() was called, in untrusted/run.js.
 		var cindent = ''
 
 		// Replace arange with range (RapydScript-NG's range function handles floats):
-		if (lang != 'javascript') program = program.replace(/arange/g, 'range')
+		if (lang == 'vpython') program = program.replace(/arange/g, 'range')
     	
 		lines = program.split('\n')
 		for (lineno=0; lineno<lines.length; lineno++) { // process individual lines of code
@@ -267,7 +269,7 @@ where compile() was called, in untrusted/run.js.
 				cindent = ''
 				cline = ''
 			}
-		    if (lang != 'javascript') {
+		    if (lang == 'vpython') {
 				if (line[0] == '#') continue
 		    } else { // eliminate comments
 				if (line.slice(0,2) == '//') {
@@ -290,7 +292,7 @@ where compile() was called, in untrusted/run.js.
 			}
 			
 			line = line.replace(/\s+$/g, '') // delete trailing spaces; later check for 'a = ', which shouldn't compile to 'a = "21";' due to line number insertions
-			if (lang != 'javascript' && line.slice(-1) == '\\') { // Python signls a continue line with a final backslash
+			if (lang == 'vpython' && line.slice(-1) == '\\') { // Python signls a continue line with a final backslash
 				cline = line.slice(0,-1)
 				cindent = indent
 				continue
@@ -299,7 +301,7 @@ where compile() was called, in untrusted/run.js.
 			m = line.match(print_optionspatt)
 		    if (m) line = line.replace(/delete/, "remove") // RapydScript-NG chokes on "delete"; print_options accepts delete or remove
 
-	    	if (lang != 'javascript' && line[0] == '@') { // such as @kwargs
+	    	if (lang == 'vpython' && line[0] == '@') { // such as @kwargs
 	    		var nextline = lines[lineno+1]
 	    		m = nextline.match(getline)
 	    		if (m[2].slice(0,3) == 'def' || m[2].slice(0,6) == 'module') {
@@ -315,7 +317,7 @@ where compile() was called, in untrusted/run.js.
 		    if (line.length === 0) continue
 		    prebraces = braces
 			
-			if (lang != 'javascript') {
+			if (lang == 'vpython') {
 			    if (classindent === indent.length) classindent = -1
 				if (line.match(classpatt)) classindent = indent.length
 		    } else {
@@ -381,7 +383,8 @@ where compile() was called, in untrusted/run.js.
 			// Handle single ('), double ("), and triple (''' or """) quotes; also count parens, brackets, and braces
 			singlequote = false
 			doublequote = false
-	    	triplequote = false // true if in the midst of """......"""
+			triplequote = false // true if in the midst of """......"""
+			backquote = false // ` used in JavaScript
 			var backslash = false
 			var string_bounds = [] // elements are [start,end, ftype] bounds on strings encountered in the line
 	    	var previouscontinuedline = continuedline
@@ -404,7 +407,7 @@ where compile() was called, in untrusted/run.js.
 		    			}
 		    			break
 					case '/':
-						if (lang != 'javascript') break
+						if (lang == 'vpython') break
 						if (line[i+1] == '/' && !singlequote && !doublequote) { // remove trailing comments
 								line = line.slice(0,i)
 								line = line.replace(/\s+$/g, '') // remove now-trailing spaces
@@ -421,21 +424,21 @@ where compile() was called, in untrusted/run.js.
 		    				triplequote = !triplequote
 		    				processedtriplequote = true
 		    				i += 2
-		    			} else {
-		    				if (char == "'") {
+		    			} else if (char == "'") {
 		    					if (!doublequote && !triplequote) {
 									if (!singlequote) string_bounds.push([i,0, fstring])
 									else string_bounds[string_bounds.length-1][1] = i
 									singlequote = !singlequote
 								}
-		    				} else { // "
-								if (!singlequote && !triplequote) {
-									if (!doublequote) string_bounds.push([i,0, fstring])
-									else string_bounds[string_bounds.length-1][1] = i
-									doublequote = !doublequote
-								}
-		    				}
-		    			}
+						} else if (char == '"') { // "
+							if (!singlequote && !triplequote) {
+								if (!doublequote) string_bounds.push([i,0, fstring])
+								else string_bounds[string_bounds.length-1][1] = i
+								doublequote = !doublequote
+							}
+						} else if (char == "`") { // ` used in JavaScript
+							if (backquote) backquote = !backquote
+						}
 		    			break
 				}
 
@@ -445,12 +448,13 @@ where compile() was called, in untrusted/run.js.
 					// this extends the surrounding for loop with "i" at the start of the original next line:
 	    			line += '\n' + lines[lineno]
 	    		}
-	    		if (singlequote || doublequote || triplequote) {
+	    		if (singlequote || doublequote || triplequote || (backquote && lang == 'javascript') ) {
 	    			if (i < line.length-1) continue
 	    			if (lineno === lines.length-1) {
 	    				var q = "single"
-	    				if (doublequote) q = "double"
-	    				else q = "triple"
+						if (doublequote) q = "double"
+						else if (triplequote) q = "triple"
+						else q = "backquote"
 	    				return "ERROR: Unbalanced "+q+" quotes, line "+(lineno+1)+": "+lines[lineno]
 	    			}
 	    		}
@@ -496,7 +500,7 @@ where compile() was called, in untrusted/run.js.
 		    			backslash = true
 		    			break
 	    		}
-			}  // End of handling single, double, and triple quotes, and counting parens, brackets, and braces
+			}  // End of handling single, double, triple, and back quotes, and counting parens, brackets, and braces
 
 			continuedline =  ( !indef && (backslash || (parens > 0) || (brackets > 0) || (braces > 0)) )
     		
@@ -524,8 +528,7 @@ where compile() was called, in untrusted/run.js.
 				return false
 			}
     		
-    		//if (lang != 'javascript') {
-    		if (true) {
+    		if (lang == 'vpython') {
 			    // When outdent line starts with ')', the element 'RS_ls = "N"' must be indented.
 			    // When outdent line starts with 'else' or 'elif', at the same level as prevous line,
 			    //   don't insert a line number; it's this case:
@@ -592,59 +595,42 @@ where compile() was called, in untrusted/run.js.
 				var newline = ''  // accumulate modified line, such as q = _GS_1
 				const methodassignpatt = new RegExp('^(\\w+)\\s*=\\s*(\\w+)\\.(\\w+)$') // p = xxx.yyy (not a call)
 				const assignpatt = new RegExp('^(\\w+)\\s*=\\s*(\\w+)\\s*')                // p = anything else
-				if (lang != 'javascript') {
-					m1 = line.match(defpatt)                           // Python def f():, can be a class method
-					if (m1 === null) m2 = line.match(classpatt)        // Python class C:
-					if (m2 === null) m3 = line.match(methodassignpatt) // Python p = xxx.yyy
-					if (m3 === null) m4 = line.match(assignpatt)       // Python p = anything else
+				m1 = line.match(defpatt)                           // Python def f():, can be a class method
+				if (m1 === null) m2 = line.match(classpatt)        // Python class C:
+				if (m2 === null) m3 = line.match(methodassignpatt) // Python p = xxx.yyy
+				if (m3 === null) m4 = line.match(assignpatt)       // Python p = anything else
 
-					// Check whether this line contains a function declaration, which will need "async"
-					if (m1 !== null) { // function declaration; can be a class method
-						var ns = start+m1.index+m1[1].length+1
-						if (instring(ns)) { // string_bounds was determined for the original line (no indent, no inserted line number)
-							line = line.slice(0,ns) + string_insert + line.slice(ns)
-						} else {
-							if (indent.length === 0 || classindent === -1) fcts.push(m1[1])
-							else if (classindent >= 0 && indent.length > classindent) classmethods.push(m1[1])
-						}
-						declaration = true
-
-					} else if (m2 !== null) { // class declaration, which is not async; its methods are async
-						classes.push(m2[1])
-						declaration = true
-
-					} else if (m3 !== null) { // p = xxx.yyy (not a call)
-						if (classinstances.indexOf(m3[2]) >= 0 && classmethods.indexOf(m3[3]) >= 0) classmethods.push(m3[1])
-
-					} else if (m4 !== null) { // p = f, where f might be a function
-						var p = m4[1]
-						var f = m4[2]
-						if (line[m4[0].length] == '(') { // p = f(...
-							var end = findrightparen(line.slice(m4[0].length))
-							if (end !== null && (m4[0].length+end+1 == line.length)) {
-								if (classes.indexOf(f) >=0) classinstances.push(p)
-								else if (classmethods.indexOf(f) >= 0) classmethods.push(p)
-								else if (fcts.indexOf(f) >= 0) fcts.push(p)
-							}
-						} else { // p = f not immediately followed by a left paren
-							;
-						}
+				// Check whether this line contains a function declaration, which will need "async"
+				if (m1 !== null) { // function declaration; can be a class method
+					var ns = start+m1.index+m1[1].length+1
+					if (instring(ns)) { // string_bounds was determined for the original line (no indent, no inserted line number)
+						line = line.slice(0,ns) + string_insert + line.slice(ns)
+					} else {
+						if (indent.length === 0 || classindent === -1) fcts.push(m1[1])
+						else if (classindent >= 0 && indent.length > classindent) classmethods.push(m1[1])
 					}
+					declaration = true
 
-				} else { // end of non-javascript
+				} else if (m2 !== null) { // class declaration, which is not async; its methods are async
+					classes.push(m2[1])
+					declaration = true
 
-					// const jsasyncpatt1 = new RegExp('\\Wfunction\\s*([\\w\.]+)\\s*\\(')   // find "function f(...)" => no change
-					const jsasyncpatt2 = new RegExp('^this\\.(\\w+)\\s*=\\s*function\\s*\\(') // find "this.f = function (" => no change
-					const jsasyncpatt3 = new RegExp('^var\\s*(\\w+)\\s*=\\s*function\\s*\\(') // find "var f = function (" => "function f("
-					const jsasyncpatt4 = new RegExp('^(\\w+)\\s*=\\s*function\\s*\\(')        // find "f = function (" => "function f("
-					const jsasyncpatt5 = new RegExp('^(\\w+)\\s*=\\s*new\\s*(\\w+)\\s*\\(') // find "f = new function (" => no change
-					m1 = line.match(jsasyncpatt1)                      // JavaScript function f(...)
-					if (m1 === null) m2 = line.match(jsasyncpatt4)     // JavaScript this.f = function ( => no change
-					if (m2 === null) m3 = line.match(jsasyncpatt2)     // JavaScript var f = function( => function f(
-					if (m3 === null) m4 = line.match(jsasyncpatt3)     // JavaScript f = function ( => function f(
-					if (m4 === null) m5 = line.match(jsasyncpatt5)     // JavaScript class creation; p = new f()
-					if (m5 === null) m6 = line.match(methodassignpatt) // JavaScript p = xxx.yyy
-					if (m7 === null) m8 = line.match(assignpatt)       // JavaScript p = anything else
+				} else if (m3 !== null) { // p = xxx.yyy (not a call)
+					if (classinstances.indexOf(m3[2]) >= 0 && classmethods.indexOf(m3[3]) >= 0) classmethods.push(m3[1])
+
+				} else if (m4 !== null) { // p = f, where f might be a function
+					var p = m4[1]
+					var f = m4[2]
+					if (line[m4[0].length] == '(') { // p = f(...
+						var end = findrightparen(line.slice(m4[0].length))
+						if (end !== null && (m4[0].length+end+1 == line.length)) {
+							if (classes.indexOf(f) >=0) classinstances.push(p)
+							else if (classmethods.indexOf(f) >= 0) classmethods.push(p)
+							else if (fcts.indexOf(f) >= 0) fcts.push(p)
+						}
+					} else { // p = f not immediately followed by a left paren
+						;
+					}
 				}
 
 				if (!declaration) { // not function declaration nor class declaration
@@ -697,86 +683,10 @@ where compile() was called, in untrusted/run.js.
 
 				newprogram += prepend+line+'\n'
 
-			} else { // javascript
-				start = 0
-				var m
-				var foundfct = false
-				// Check whether this line contains "new" for constructing an object
-				const newpatt = new RegExp('(\\w+)\\s*=\\s*new\\s*(\\w*)\\s*\\(') // new f()
-				m = line.match(newpatt)
-				if (m !== null) {
-					var ns = m.index+m[1].length+1
-					if (instring(ns)) { // string_bounds was determined for the original line (no indent, no inserted line number)
-						line = line.slice(0,ns) + string_insert + line.slice(ns)
-					} else {
-						var look = fcts.indexOf(m[2])
-						if (look >= 0) fcts.splice(look,1)
-						classinstances.push(m[1])
-						classes.push(m[2])
-						start += m.index+m[0].length
-						foundfct = true
-					}
-				}
-
-				//if (!foundfct) {
-				if (false) {
-					// Check whether this line contains a function definition, which will need "async"
-					var name
-					// const jsasyncpatt1 = new RegExp('\\Wfunction\\s*([\\w\.]+)\\s*\\(')      // find "function f(...." => no change
-					const jsasyncpatt2 = new RegExp('var\\s*(\\w+)\\s*=\\s*function\\s*\\(') // find "var f = function (..." => "function f ("
-					const jsasyncpatt3 = new RegExp('(\\w+)\\s*=\\s*function\\s*\\(') // find "f = function (..." => "function f ("
-					const jsasyncpatt4 = new RegExp('this\\.(\\w+)\\s*=\\s*function\\s*\\(') // find "this.f = function (..." => no change
-					const jsasyncpatt5 = new RegExp('(\\w+)\\s*=\\s*new\\s*function\\s*\\(') // find "f = new function (..." => no change
-					m = line.match(jsasyncpatt1)
-					if (m !== null) {
-						name = m[1]
-						if (fcts.indexOf(name) < 0) fcts.push(name)
-						foundfct = true
-						start += m[0].length
-					} else {
-						m = line.match(jsasyncpatt2)
-						if (m !== null) {
-							var ins = instring(start)
-							if (ins) {
-								line = line.slice(0,start+1+m[1].length) + string_insert + line.slice(start+1+m[1].length)
-								start += string_insert.length
-							} else {
-								name = m[1]
-								if (name.slice(0,5) == 'this.') {
-									name = name.slice(5)
-									if (classmethods.indexOf(name) < 0) classmethods.push(name)
-								} else if (fcts.indexOf(name) < 0) fcts.push(name)
-								foundfct = true
-								var p = line.search(/\(/)
-								start = p
-							}
-						}
-					}
-				}
-
-				if (!foundfct) {
-					// Check whether this line contains function calls inside strings, which will not need "await"
-					// const awaitpatt = new RegExp('\\W(\\w+)\\s*\\(')  // find a function call
-					while (true) {
-						var m = line.slice(start).match(awaitpatt)
-						if (m !== null) {
-							start += m.index
-							var ins = instring(start)
-							if (ins) {
-								line = line.slice(0,start+1+m[1].length) + string_insert + line.slice(start+1+m[1].length)
-								start += string_insert.length
-							}
-							start += m[1].length+1
-						} else break
-					}
-				}
+			} // end of vpython procesing of class and function issues
 				
-				// Give up for now introducing line numbers into a JavaScript program; would need to check for example
-				// (as is done for Python) not to put a line number between an if and an else if.
-				// if (previouscontinuedline || braces > 0) line = indent+line+'\n'
-				// else line = indent+lineno_string+delim+(lineno+3)+delim+';\n'+line+'\n'
-				newprogram += indent+line+'\n'
-			}
+			// Give up for now introducing line numbers into a JavaScript program; would need to check for example
+			// (as is done for Python) not to put a line number between an if and an else if.
 
 		    lastindent = indent
 		    if (parens < 0) return "ERROR: Too many right parentheses, line "+(lineno+1)+": "+lines[lineno]
@@ -821,7 +731,7 @@ where compile() was called, in untrusted/run.js.
 		}
     }
 
-    // vp_primitives come in two flavors: "box" for JavaScript/RapydScript and "vp_box" for VPython
+    // vp_primitives come in two flavors: "box" for JavaScript and "vp_box" for VPython
     var vp_primitives = ["box", "sphere", "simple_sphere", "cylinder", "pyramid", "cone", "helix", "ellipsoid", "ring", "arrow", "compound"]
     
     var vp_other = ["canvas", "vec", "vector", "rate", "sleep", "update", "color", "extrusion", "paths", "shapes",
@@ -831,7 +741,7 @@ where compile() was called, in untrusted/run.js.
                     "radians", "degrees", "get_library", "read_local_file"]
     
     function compile(program, options) {
-    	// options include lang ('javascript' or 'rapydscript' or 'vpython'), version,
+    	// options include lang ('javascript' or 'vpython'), version,
     	//     run (true if will run the code, false if compiling for sharing, in which case don't call fontloading)
     	options = options || {}
     	window.__original = {text: program.split("\n")}
@@ -854,12 +764,12 @@ where compile() was called, in untrusted/run.js.
 		}
 		
 		var endprog
-		program = preprocess(program, options.lang)
-        if (options.lang != 'javascript') { // handle Python imports
+        if (options.lang == 'vpython') { 
+			program = preprocess(program, options.lang)
     		var vars = ''
         	if (program.slice(0,7) == 'ERROR: ') {
         		compile_rapydscript(program)
-        	} else {
+        	} else {// handle Python imports
 				var prog
 				// if pop(), leave as is to work ok with both lists and sets, but if pop(N), which is only found with lists, use pypop(N)
 				program = program.replace(/(\.pop\s*\(\s*)([^)]*)/g, pop_replace)
@@ -867,61 +777,56 @@ where compile() was called, in untrusted/run.js.
 				prog = "def __main__():\n  version = "+version+"\n"
 				// The following turned out to slow all calculations down by about a factor of 5 and so was abandoned:
 				//prog += "  from __python__ import dict_literals, overload_getitem\n" // so that dictionaries behave like Python dictionaries
-				if (options.lang == 'rapydscript') {
-					prog += "  window.__GSlang = 'rapydscript'\n" // WebGLRenderer needs to know at run time what models to create
-					prog += vars + "  display=canvas\n  vector=vec\n"
-				} else if (options.lang == 'vpython') {
-					prog += "  window.__GSlang = 'vpython'\n" // WebGLRenderer needs to know at run time what models to create
-					if ( VPython_import === null) {
-						for (var i = 0; i<vp_primitives.length; i++) prog += "  "+vp_primitives[i]+"=vp_"+vp_primitives[i]+"\n"
-						prog += "  display=canvas\n  vector=vec\n"
-					} else if (VPython_names.length > 0) { // e.g from vpython import box, cylinder
-						vars += "  vector=vec\n"
-						for (var i=0; i<vp_primitives.length; i++) {
-							var name = vp_primitives[i]
-							var n = VPython_names.indexOf(name)
-							if (n >= 0) vars += "  "+name+"=vp_"+name+"\n"
-							else vars += "  "+name+"=undefined\n"
-						}
-						var hasvector = (VPython_names.indexOf('vector') >= 0)
-						for (var i=0; i<vp_other.length; i++) {
-							var name = vp_other[i]
-							if (name == 'vec' && hasvector) continue
-							var n = VPython_names.indexOf(name)
-							if (n < 0) vars += "  "+name+"=undefined\n"  // just undefine those entities not listed in the import; those listed need no mention
-						}
-						prog += vars
-					} else { // import vpython or visual or vis, or import vpython or visual or vis as (VPython_import)
-						var importpatt = new RegExp(VPython_import+'\\.(\\w+)', 'g')
-						var m = program.match(importpatt) // has the form [vis.vector, vis.rate, vis.vector, .....]
-						importpatt = new RegExp(VPython_import+'\\.(\\w+)')
-						var attrs = {} // a dictionary containing all the objects referenced in the program
-						for (var i=0; i<m.length; i++) {
-							var a = importpatt.exec(m[i])[1] // extract "rate" from "vis.rate" or "visual.rate"
-							if (!(a in attrs)) attrs[a] = a
-						}
-						var purge = '' // set variables unqualified by vis. or visual. to "undefined"
-						vars += '    var '+VPython_import+'={'
-						for (var i=0; i<vp_primitives.length; i++) {
-							var name = vp_primitives[i]
-							if (name in attrs) vars += name+':vp_'+name+', '
-							else purge += "  "+name+'=undefined\n'
-						}
-						vars += 'canvas:canvas, '
-						for (var i=0; i<vp_other.length; i++) {
-							var name = vp_other[i]
-							if (name == 'canvas') continue
-							if (name in attrs) {
-								if (name == 'vector') vars += 'vector:vec, '
-								else vars += name+':'+name+', '
-							} else {
-								if (name == 'vec' && ('vector' in attrs)) continue
-								purge += "  "+name+'=undefined\n'
-							}
-						}
-						vars = vars.slice(0,-2)+'}\n'
-						prog += purge
+				prog += "  window.__GSlang = 'vpython'\n" // WebGLRenderer needs to know at run time what models to create
+				if ( VPython_import === null) {
+					for (var i = 0; i<vp_primitives.length; i++) prog += "  "+vp_primitives[i]+"=vp_"+vp_primitives[i]+"\n"
+					prog += "  display=canvas\n  vector=vec\n"
+				} else if (VPython_names.length > 0) { // e.g from vpython import box, cylinder
+					vars += "  vector=vec\n"
+					for (var i=0; i<vp_primitives.length; i++) {
+						var name = vp_primitives[i]
+						var n = VPython_names.indexOf(name)
+						if (n >= 0) vars += "  "+name+"=vp_"+name+"\n"
+						else vars += "  "+name+"=undefined\n"
 					}
+					var hasvector = (VPython_names.indexOf('vector') >= 0)
+					for (var i=0; i<vp_other.length; i++) {
+						var name = vp_other[i]
+						if (name == 'vec' && hasvector) continue
+						var n = VPython_names.indexOf(name)
+						if (n < 0) vars += "  "+name+"=undefined\n"  // just undefine those entities not listed in the import; those listed need no mention
+					}
+					prog += vars
+				} else { // import vpython or visual or vis, or import vpython or visual or vis as (VPython_import)
+					var importpatt = new RegExp(VPython_import+'\\.(\\w+)', 'g')
+					var m = program.match(importpatt) // has the form [vis.vector, vis.rate, vis.vector, .....]
+					importpatt = new RegExp(VPython_import+'\\.(\\w+)')
+					var attrs = {} // a dictionary containing all the objects referenced in the program
+					for (var i=0; i<m.length; i++) {
+						var a = importpatt.exec(m[i])[1] // extract "rate" from "vis.rate" or "visual.rate"
+						if (!(a in attrs)) attrs[a] = a
+					}
+					var purge = '' // set variables unqualified by vis. or visual. to "undefined"
+					vars += '    var '+VPython_import+'={'
+					for (var i=0; i<vp_primitives.length; i++) {
+						var name = vp_primitives[i]
+						if (name in attrs) vars += name+':vp_'+name+', '
+						else purge += "  "+name+'=undefined\n'
+					}
+					vars += 'canvas:canvas, '
+					for (var i=0; i<vp_other.length; i++) {
+						var name = vp_other[i]
+						if (name == 'canvas') continue
+						if (name in attrs) {
+							if (name == 'vector') vars += 'vector:vec, '
+							else vars += name+':'+name+', '
+						} else {
+							if (name == 'vec' && ('vector' in attrs)) continue
+							purge += "  "+name+'=undefined\n'
+						}
+					}
+					vars = vars.slice(0,-2)+'}\n'
+					prog += purge
 				}
 				prog += "  print = GSprint\n"
 				prog += "  arange = range\n"
@@ -942,203 +847,205 @@ where compile() was called, in untrusted/run.js.
 	        	if (VPython_names.length <= 0) arr += vars
 				program = program.slice(0,start) + arr + program.slice(start-4)
 			} // end handle Python imports
-			//program = program.replace(new RegExp('\\(function\\(\\)', 'g'), '(async function()')
         	
 		} else { // JavaScript
-            var prog = 'function __main__() {\n"use strict";\n'
-            prog += "var version = "+version+";\n"
+            //var p = 'async function __main__() {\n"use strict";\n'
+			//var p = 'async function __main__() {\n'
+			var p = 'function __main__() {\n'
+            p += "var version = "+version+";\n"
             	
             // This string formatting machinery was originally used by both Python and JavaScript,
             // but with the change to rapydscript-ng, which has its own format method, Python uses
             // the rapydscript-ng method, and the following is used only by JavaScript programs.
-			prog += "Array.prototype.toString = function() { return __parsearray(this) };\n"
+			p += "Array.prototype.toString = function() { return __parsearray(this) };\n"
 			
-            prog += "var scene = canvas();\n"
-			program = prog + program + "\n}"
+            p += "var scene = canvas();\n"
+			program = p + program + "\n}"
 		}
+
+		program = program.replace('function __main__() {', 'async function __main__() {\n"use strict";\n')
 		
 		// handle operator overloading
-		var start = program.indexOf("function __main__()")
+		var start = program.indexOf("async function __main__()")
 		var prog = program.slice(start)
 		prog = papercompile(prog)
 		prog = program.slice(0,start)+prog
-		prog = prog.replace("function __main__()", "async function __main__()")
 		prog = ';\n'+prog // so don't have to make special checks when searching backwards
 
 		// ------------------- Handle async and await issues ------------------------
 	
 		// Must delete class statements of the form classname.prototype.RS_ls = "11";
 		// which RapypdScript reduces to classname.prototype."11";
-		if (options.lang != "javascript") {
+		if (options.lang == "vpython") {
 			const classproto = new RegExp('\\w+\\.prototype\\.'+lineno_string+'"\\w+";', 'g')
 			prog = prog.replace(classproto, '')
-		}
 		
-		var start, m, name
-		var initialstart = prog.search(lineno_string)
-		start = initialstart
+			var start, m, name
+			var initialstart = prog.search(lineno_string)
+			start = initialstart
 
-		// Prepend 'async ' to all user functions
-		while (true) {
-			// const asyncpatt1 =   new RegExp('\\Wfunction\\s*(\\w+)\\s*\\(')      // find "function f(...."
-			// const jsasyncpatt1 = new RegExp('\\Wfunction\\s*([\\w\.]+)\\s*\\(')      // find "function f(...."
-			// if (options.lang != 'javascript') m = prog.slice(start).match(asyncpatt1)
-			// else m = prog.slice(start).match(jsasyncpatt2)
-			m = prog.slice(start).match(asyncpatt1)
-			if (m === null) break
-			name = m[1]
-			if (classes.indexOf(name) >= 0) { // A class is not async; its methods are
-				// if (options.lang == 'javascript' && fcts.indexOf(m[1]) >= 0) {
-				// 	throw new Error('Currently in version >= 2.9, cannot create '+name+' class with "new".')
-				// }
-				start += m[0].length
-				continue
-			}
-			//prog = prog.slice(0,start+m.index+1)+'async function '+name+string_insert+prog.slice(start+m.index+m[0].length-1)
-			// prog = prog.slice(0,start+m.index+1)+name+string_insert+' = async function'+prog.slice(start+m.index+m[0].length-1)
-			// start += m.index+'async function '.length+m[1].length+string_insert.length+1
-
-			
-			prog = prog.slice(0,start+m.index+1)+'async function '+name+string_insert+prog.slice(start+m.index+m[0].length-1)
-			start += m.index+'async function '.length+m[1].length+string_insert.length+1
-		}
-			
-		// Prepend "await " to calls to user functions and the GlowScript async functions (all user functions and class methods are marked async).
-		start = initialstart
-								
-		// VPython_import is the prefix of VPython objects, with value 'null' if no import statement
-		// const awaitpatt = new RegExp('\\W(\\w+)\\s*\\(')  // find a function call
-		while (true) {
-			m = prog.slice(start).match(awaitpatt)
-			var period = false
-			if (m === null) break
-			period = (prog[start+m.index] == '.')
-			name = m[1]
-
-			// If this is a class, delete the call to __init__ (we will insert this call after creating the class instance)
-			if (options.lang != 'javascript' && !period && classes.indexOf(name) >= 0) {
-				start += m.index+name.length+1
-				var lbrace = prog.slice(start).search('{')
-				var rbrace = prog.slice(start).search('arguments')
-				prog = prog.slice(0,start+lbrace+1)+prog.slice(start+'arguments'.length+rbrace+1)
-				continue
-			}
-
-			// Might start with 'RS_' or be "....".option(...)
-			//if ( name.slice(0,3) == 'RS_' || (period && (prog[start+m.index-1] == '"'))  ) {
-			if ( name.slice(0,3) == 'RS_') {
-				start += m.index+name.length+1
-				continue
-			}
-
-			// find the beginning of ....f()
-			var ptr = start+m.index+1
-			var brackets = 0
-			var parens = 0
+			// Prepend 'async ' to all user functions
 			while (true) {
-				ptr--
-				if (prog[ptr] == ']') {
-					brackets--
-				} else if (prog[ptr] == '[') {
-					if (brackets === 0) break
-					brackets++
-				} else if (prog[ptr] == ')') {
-					parens--
-				} else if (prog[ptr] == '(') {
-					if (parens === 0) break
-					parens++
+				// const asyncpatt1 =   new RegExp('\\Wfunction\\s*(\\w+)\\s*\\(')      // find "function f(...."
+				// const jsasyncpatt1 = new RegExp('\\Wfunction\\s*([\\w\.]+)\\s*\\(')      // find "function f(...."
+				if (options.lang == 'vpython') m = prog.slice(start).match(asyncpatt1)
+				// else m = prog.slice(start).match(jsasyncpatt2)
+				m = prog.slice(start).match(asyncpatt1)
+				if (m === null) break
+				name = m[1]
+				if (classes.indexOf(name) >= 0) { // A class is not async; its methods are
+					// if (options.lang == 'javascript' && fcts.indexOf(m[1]) >= 0) {
+					// 	throw new Error('Currently in version >= 2.9, cannot create '+name+' class with "new".')
+					// }
+					start += m[0].length
+					continue
 				}
-				if (prog[ptr] == ' ') {
-					if (brackets === 0 && parens === 0) break
+				//prog = prog.slice(0,start+m.index+1)+'async function '+name+string_insert+prog.slice(start+m.index+m[0].length-1)
+				// prog = prog.slice(0,start+m.index+1)+name+string_insert+' = async function'+prog.slice(start+m.index+m[0].length-1)
+				// start += m.index+'async function '.length+m[1].length+string_insert.length+1
+
+				
+				prog = prog.slice(0,start+m.index+1)+'async function '+name+string_insert+prog.slice(start+m.index+m[0].length-1)
+				start += m.index+'async function '.length+m[1].length+string_insert.length+1
+			} // end of prepending 'async' to user functions
+				
+			// Prepend "await " to calls to user functions and the GlowScript async functions (all user functions and class methods are marked async).
+			start = initialstart
+									
+			// VPython_import is the prefix of VPython objects, with value 'null' if no import statement
+			// const awaitpatt = new RegExp('\\W(\\w+)\\s*\\(')  // find a function call
+			while (true) {
+				m = prog.slice(start).match(awaitpatt)
+				var period = false
+				if (m === null) break
+				period = (prog[start+m.index] == '.')
+				name = m[1]
+
+				// If this is a class, delete the call to __init__ (we will insert this call after creating the class instance)
+				if (options.lang == 'vpython' && !period && classes.indexOf(name) >= 0) {
+					start += m.index+name.length+1
+					var lbrace = prog.slice(start).search('{')
+					var rbrace = prog.slice(start).search('arguments')
+					prog = prog.slice(0,start+lbrace+1)+prog.slice(start+'arguments'.length+rbrace+1)
+					continue
 				}
-			}
-			
-			var pstart = ptr+1 // start of ....f()
-			var prefix = ''
-			if (period) {
-				prefix = prog.slice(pstart,start+m.index)
-			}
-			// RapydScript-NG leaves string.replace unchanged from JavaScript, so for
-			// VPython we invoke string.__GSrep(), implemented in vectors.js, to mimic Python:
-			if (options.lang != 'javascript' && period && classinstances.indexOf(prefix) < 0 && name == 'replace') {
-				prog = prog.slice(0,start+m.index+1) + '__GSrep' + prog.slice(start+m.index+name.length+1)
-				start += m.index+name.length+1
-				continue
-			}
 
-			// Python and VPython and JavaScript key words that can precede '(':
-			var no_await = ['if', 'elif', 'return', 'for', 'while', 'function', 'else', 'dict',
-				'float', 'hex', 'int', 'iter', 'len', 'list', 'vec', 'vector',
-				'oct', 'ord', 'print', 'range', 'arange', 'update', 'print', 'GSprint', 'clock', 'msclock',
-				'canvas', 'graph', 'gcurve', 'gdots', 'gvbars', 'ghbars', 'rotate', 'box', 'cylinder',
-				'cone', 'pyramid', 'sphere', 'simple_sphere', 'arrow', 'curve', 'points', 'paths',
-				'shapes', 'helix', 'ring', 'compound', 'vertex', 'triangle', 'quad', 'label', 
-				'distant_light', 'local_light', 'attach_trail', 'attach_arrow', 'text', 'extrusion',
-				'wtext', 'winput', 'radio', 'checkbox', 'button', 'slider', 'menu', 'input',
-				'mag', 'mag2', 'norm', 'hat', 'dot', 'cross', 'proj', 'diff_angle', 'GS_power',
-				'abs', 'sin', 'cos', 'tan', 'asin', 'acos', 'atan', 'atan2', 'exp', 'log', 'pow', 'sqrt', 
-				'ceil', 'floor', 'sign', 'round', 'max', 'min', 'random', "factorial", "combin"]
+				// Might start with 'RS_' or be "....".option(...)
+				//if ( name.slice(0,3) == 'RS_' || (period && (prog[start+m.index-1] == '"'))  ) {
+				if ( name.slice(0,3) == 'RS_') {
+					start += m.index+name.length+1
+					continue
+				}
 
-			// Python and VPython key words that can be preceded by 'xxx.'
-			// 'defineProperties' is a RapydScript-NG element.
-			var no_await2 = ['remove', 'select', 'append_to_title', 'append_to_caption', 'bind', 'unbind', 'call',
-							 'rgb_to_hsv', 'hsv_to_rgb', 'mag', 'mag2', 'norm', 'hat', 'rotate', 'random',
-							 'format', 'trigger', 'follow', 'defineProperties', 'textures', 'bumpmaps']
+				// find the beginning of ....f()
+				var ptr = start+m.index+1
+				var brackets = 0
+				var parens = 0
+				while (true) {
+					ptr--
+					if (prog[ptr] == ']') {
+						brackets--
+					} else if (prog[ptr] == '[') {
+						if (brackets === 0) break
+						brackets++
+					} else if (prog[ptr] == ')') {
+						parens--
+					} else if (prog[ptr] == '(') {
+						if (parens === 0) break
+						parens++
+					}
+					if (prog[ptr] == ' ') {
+						if (brackets === 0 && parens === 0) break
+					}
+				}
+				
+				var pstart = ptr+1 // start of ....f()
+				var prefix = ''
+				if (period) {
+					prefix = prog.slice(pstart,start+m.index)
+				}
+				// RapydScript-NG leaves string.replace unchanged from JavaScript, so for
+				// VPython we invoke string.__GSrep(), implemented in vectors.js, to mimic Python:
+				if (options.lang == 'vpython' && period && classinstances.indexOf(prefix) < 0 && name == 'replace') {
+					prog = prog.slice(0,start+m.index+1) + '__GSrep' + prog.slice(start+m.index+name.length+1)
+					start += m.index+name.length+1
+					continue
+				}
 
-							 
-			// If not a user function, nor pause/waitfor/rate/sleep/read_local_file/get_library,
-			// nor prefix is VPython_import, don't prepend await to this function call.
-			// There is a risk of prepending await unecessarily. If there is a user method "F" and
-			// and a user method "rotate", and there is a box named "B", then "B.rotate()" will be
-			// prepended by await, which is unnecessary (but not horribly expensive). This has to
-			// be tolerated: Suppose the user says "for obj in objects: obj.rotate(...)"; it would
-			// be difficult in the transpiling to know whether "obj" is a user object or a VPython object,
-			// both of which have rotate methods, but only the user object needs await.
-			if ( // Test for cases that need await:
-				(period && prefix == 'self') ||                                                // in self.f, f may be a function passed to __init__
-				(!period && fcts.indexOf(name) >= 0) ||                                        // f()
-				(period && classes.indexOf(prefix) >= 0 && classmethods.indexOf(name) >= 0) || // userclass.usermethod()
-				(!period && classmethods.indexOf(name) >= 0) ||                                // usermethod(), preceded by usermethod = userclass.method()
-				(!period && classes.indexOf(name) >= 0) ||                                     // userclass()
-				(period && classinstances.indexOf(prefix) < 0 && vpfcts.indexOf(name) >= 0) || // scene.pause(), scene.waitfor(), scene.capture()
-				(period && prefix == VPython_import && fcts.indexOf(name) >= 0 &&
-						fcts.indexOf(name) < 4) ||                                            // vp.rate/vp.sleep/vp.get_library/vp.read_local_file
-				(period && no_await2.indexOf(name) < 0) ||                                     // scene.bind()
-				(!period && no_await.indexOf(name) < 0)) {                                     // cos()
-				;
-			} else {  // no need to prepend await
-				start += m.index+name.length+1
-				continue
-			}
+				// Python and VPython and JavaScript key words that can precede '(':
+				var no_await = ['if', 'elif', 'return', 'for', 'while', 'function', 'else', 'dict',
+					'float', 'hex', 'int', 'iter', 'len', 'list', 'vec', 'vector',
+					'oct', 'ord', 'print', 'range', 'arange', 'update', 'print', 'GSprint', 'clock', 'msclock',
+					'canvas', 'graph', 'gcurve', 'gdots', 'gvbars', 'ghbars', 'rotate', 'box', 'cylinder',
+					'cone', 'pyramid', 'sphere', 'simple_sphere', 'arrow', 'curve', 'points', 'paths',
+					'shapes', 'helix', 'ring', 'compound', 'vertex', 'triangle', 'quad', 'label', 
+					'distant_light', 'local_light', 'attach_trail', 'attach_arrow', 'text', 'extrusion',
+					'wtext', 'winput', 'radio', 'checkbox', 'button', 'slider', 'menu', 'input',
+					'mag', 'mag2', 'norm', 'hat', 'dot', 'cross', 'proj', 'diff_angle', 'GS_power',
+					'abs', 'sin', 'cos', 'tan', 'asin', 'acos', 'atan', 'atan2', 'exp', 'log', 'pow', 'sqrt', 
+					'ceil', 'floor', 'sign', 'round', 'max', 'min', 'random', "factorial", "combin"]
 
-			// Ignore function calls that are inserted by the RapydScript-NG transpiler:
-			if (options.lang != 'javascript' && prog.slice(pstart,start+m.index).search('RS_') >= 0) {
-				start += m.index+name.length+1
-				continue
-			}
+				// Python and VPython key words that can be preceded by 'xxx.'
+				// 'defineProperties' is a RapydScript-NG element.
+				var no_await2 = ['remove', 'select', 'append_to_title', 'append_to_caption', 'bind', 'unbind', 'call',
+								'rgb_to_hsv', 'hsv_to_rgb', 'mag', 'mag2', 'norm', 'hat', 'rotate', 'random',
+								'format', 'trigger', 'follow', 'defineProperties', 'textures', 'bumpmaps']
 
-			// Back up over spaces to see whether we need a semicolon
-			var prepend = '('
-			while (prog[ptr] == ' ') ptr--
-			if (prog[ptr] == '\n') {
-				prepend = ';(' // if a line starts with an await call, need a semicolon to avoid (await f()) going with previous line
-			}
+								
+				// If not a user function, nor pause/waitfor/rate/sleep/read_local_file/get_library,
+				// nor prefix is VPython_import, don't prepend await to this function call.
+				// There is a risk of prepending await unecessarily. If there is a user method "F" and
+				// and a user method "rotate", and there is a box named "B", then "B.rotate()" will be
+				// prepended by await, which is unnecessary (but not horribly expensive). This has to
+				// be tolerated: Suppose the user says "for obj in objects: obj.rotate(...)"; it would
+				// be difficult in the transpiling to know whether "obj" is a user object or a VPython object,
+				// both of which have rotate methods, but only the user object needs await.
+				if ( // Test for cases that need await:
+					(period && prefix == 'self') ||                                                // in self.f, f may be a function passed to __init__
+					(!period && fcts.indexOf(name) >= 0) ||                                        // f()
+					(period && classes.indexOf(prefix) >= 0 && classmethods.indexOf(name) >= 0) || // userclass.usermethod()
+					(!period && classmethods.indexOf(name) >= 0) ||                                // usermethod(), preceded by usermethod = userclass.method()
+					(!period && classes.indexOf(name) >= 0) ||                                     // userclass()
+					(period && classinstances.indexOf(prefix) < 0 && vpfcts.indexOf(name) >= 0) || // scene.pause(), scene.waitfor(), scene.capture()
+					(period && prefix == VPython_import && fcts.indexOf(name) >= 0 &&
+							fcts.indexOf(name) < 4) ||                                            // vp.rate/vp.sleep/vp.get_library/vp.read_local_file
+					(period && no_await2.indexOf(name) < 0) ||                                     // scene.bind()
+					(!period && no_await.indexOf(name) < 0)) {                                     // cos()
+					;
+				} else {  // no need to prepend await
+					start += m.index+name.length+1
+					continue
+				}
 
-			// find the end of f(.....)
-			var temp = start+m.index+name.length+1
-			var pend = findrightparen(prog.slice(temp))
-			pend += temp
+				// Ignore function calls that are inserted by the RapydScript-NG transpiler:
+				if (options.lang == 'vpython' && prog.slice(pstart,start+m.index).search('RS_') >= 0) {
+					start += m.index+name.length+1
+					continue
+				}
 
-			// To my dismay, I found that "!" requires this special handling:
-			var pst = pstart
-			if (prog[pstart] == '!') {
-				if (prepend == '(') prepend = '!('
-				else prepend = ';!('
-				pstart++
-			}
-			prog = prog.slice(0,pst)+prepend+'await '+prog.slice(pstart,pend)+')'+prog.slice(pend)
-			start += m.index+name.length+prepend.length+6
-		} // end of adding "await " to function calls
+				// Back up over spaces to see whether we need a semicolon
+				var prepend = '('
+				while (prog[ptr] == ' ') ptr--
+				if (prog[ptr] == '\n') {
+					prepend = ';(' // if a line starts with an await call, need a semicolon to avoid (await f()) going with previous line
+				}
+
+				// find the end of f(.....)
+				var temp = start+m.index+name.length+1
+				var pend = findrightparen(prog.slice(temp))
+				pend += temp
+
+				// To my dismay, I found that "!" requires this special handling:
+				var pst = pstart
+				if (prog[pstart] == '!') {
+					if (prepend == '(') prepend = '!('
+					else prepend = ';!('
+					pstart++
+				}
+				prog = prog.slice(0,pst)+prepend+'await '+prog.slice(pstart,pend)+')'+prog.slice(pend)
+				start += m.index+name.length+prepend.length+6
+			} // end of adding "await " to function calls
+		} // end of processing VPython class and function issues
 
 		program = prog.replace(/\n\n\n\n/g, '') // eliminate lots of white space
 

--- a/lib/compiling/papercomp.js
+++ b/lib/compiling/papercomp.js
@@ -141,6 +141,6 @@ function papercompile(code) {
 	            break;
         }
     }
-    walkAST(window.call_acorn_parse(code, { ranges: true })); 
+    walkAST(window.call_acorn_parse(code, { ranges: true }));  // default ecmaVersion currently (May 2020) is 10 (2019)
     return code;
 }


### PR DESCRIPTION
For GlowScript 3.0, in a JavaScript program the programmer will have to provide explicit async and await where needed, unlike the Python situation where these are inserted automatically. Probably few people write GlowScript JavaScript programs, but those that do obviously have the programming experience to do this. It makes sense to maintain a JavaScript capability, including for JavaScript programmers who might use the GlowScript library in a completely JavaScript environment, but it doesn't make sense to spend scarce resources creating and supporting a complex pre- and post-processing of JavaScript programs.