### PR TITLE
Add screenshot method considering overlay canvas

### DIFF
--- a/lib/glow/canvas.js
+++ b/lib/glow/canvas.js
@@ -311,13 +311,34 @@
             	canvas.trigger(ev.type, ev)
             })
         },
-        
-        capture: async function(filename) { // send image of canvas to Download directory
+	    
+        screenshot: async function(include_overlay = true){ // return screenshot as data url
+            var img = await this.__renderer.screenshot();
+
+            if (include_overlay){
+                // combine WebGL image with overlay canvas
+                var overlay = this.__overlay_element;
+                var c = document.createElement('canvas');
+                c.width = overlay.width;
+                c.height = overlay.height;
+                await new Promise(r => img.onload=r); // wait for image to be loaded
+                c.getContext("2d").drawImage(img, 0, 0);
+                c.getContext("2d").drawImage(overlay, 0, 0);
+                var data = c.toDataURL();
+                c.remove();
+                return data;
+
+            } else {
+                return img.src;
+            }
+        },
+
+        capture: async function(filename, include_overlay = true){ // send image of canvas to Download directory
         	if (filename.constructor !== String) throw new Error('A capture file name must be a string.')
         	if (filename.slice(-4) != '.png') filename += '.png'
-            var img = await this.__renderer.screenshot()
+            var screenshot = await this.screenshot(include_overlay);
             var a = document.createElement("a")
-            a.href = img.src
+            a.href = screenshot
             a.download = filename
             a.click()
             a.remove()

--- a/lib/glow/canvas.js
+++ b/lib/glow/canvas.js
@@ -321,7 +321,7 @@
                 var c = document.createElement('canvas');
                 c.width = overlay.width;
                 c.height = overlay.height;
-                await new Promise(r => img.onload=r); // wait for image to be loaded
+                await img.decode(); // wait for image to be loaded
                 c.getContext("2d").drawImage(img, 0, 0);
                 c.getContext("2d").drawImage(overlay, 0, 0);
                 var data = c.toDataURL();


### PR DESCRIPTION
- Adds method `screenshot(include_overlay = true)` to returns the screenshot as DataURL, considering not only the rendered 3D WebGL scene but also the overlay canvas (where labels are drawn).
- Update method `capture(filename, include_overlay = true)` to also consider the overlay canvas.

For backwards compatibility, a screenshot without the overlay canvas can still be generated by setting the optional parameter `include_overlay` to `false`.

Fixes https://github.com/vpython/vpython-jupyter/issues/152